### PR TITLE
Update/help menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -284,9 +284,9 @@ const windowMenu = [{
 
 const helpMenu = [{
     label: 'Find Help',
-    sublabel: 'View Related Issues on GitHub',
+    sublabel: 'Get Help on WALC Troubleshooting Board',
     click: () => {
-        shell.openExternal(walcinfo.bugs.url);
+        shell.openExternal("https://github.com/cstayyab/WALC/discussions/categories/troubleshooting");
     },
     accelerator: 'F1'
 }, {

--- a/main.js
+++ b/main.js
@@ -302,7 +302,7 @@ const helpMenu = [{
     label: 'Request a Feature',
     sublabel: 'Create a new feature request on GitHub',
     click: () => {
-        shell.openExternal(walcinfo.bugs.url + "/new/?template=feature_request.md&labels=enhancement&title=[Feature+Request]");
+        shell.openExternal('https://github.com/cstayyab/WALC/discussions/categories/feature-requests');
     }
 }, {
     label: 'Vote for a Feature',

--- a/main.js
+++ b/main.js
@@ -304,13 +304,15 @@ const helpMenu = [{
     click: () => {
         shell.openExternal('https://github.com/cstayyab/WALC/discussions/categories/feature-requests');
     }
-}, {
-    label: 'Vote for a Feature',
-    sublabel: 'Vote for existing features on FeatHub',
-    click: () => {
-        shell.openExternal("https://feathub.com/cstayyab/WALC");
-    }
-}, {
+}, 
+// {
+//     label: 'Vote for a Feature',
+//     sublabel: 'Vote for existing features on FeatHub',
+//     click: () => {
+//         shell.openExternal("https://feathub.com/cstayyab/WALC");
+//     }
+// }, 
+{
     label: 'separator',
     type: 'separator'
 }, {


### PR DESCRIPTION
Fixes Issue #87 @cstayyab/WALC

-  Redirect "Find Help" menu to Troubleshooting Discussion Board and update its sublabel to "Get Help on WALC Troubleshooting Board"

- Redirect "Request a Feature" menu to Feature Requests Discussion Board

- Hide "Vote for a Feature" menu for the time being but do not fully remove it.
